### PR TITLE
Remove little deprecation note since this also was done on Scramjet repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ The demo implementation of <a href="https://github.com/MercuryWorkshop/scramjet"
 
 <a href="https://github.com/MercuryWorkshop/scramjet">Scramjet</a> is an experimental interception based web proxy designed with security, developer friendliness, and performance in mind. This project is made to evade internet censorship and bypass arbitrary web browser restrictions.
 
-#### Refer to <a href="https://github.com/HeyPuter/browser.js">browser.js</a> where this project will now receive updates outside of just bypassing internet censorship.
 
 ## Supported Sites
 


### PR DESCRIPTION
Since the similar message got removed on Scramjet, I deemed it appropriate to do it to the example app too.