### PR TITLE
Use epoxy transport instead of libcurl for WebKit compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 		"@mercuryworkshop/libcurl-transport": "^1.5.2",
 		"@mercuryworkshop/scramjet": "https://github.com/MercuryWorkshop/scramjet/releases/download/latest/mercuryworkshop-scramjet-2.0.0-alpha.tgz",
 		"@mercuryworkshop/wisp-js": "^0.4.1",
-		"ws": "^8.18.3"
+		"ws": "^8.18.3",
+		"@mercuryworkshop/epoxy-transport": "^3.0.1"
 	},
 	"devDependencies": {
 		"eslint": "^9.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@mercuryworkshop/bare-mux':
         specifier: ^2.1.7
         version: 2.1.7
+      '@mercuryworkshop/epoxy-transport':
+        specifier: ^3.0.1
+        version: 3.0.1
       '@mercuryworkshop/libcurl-transport':
         specifier: ^1.5.2
         version: 1.5.2
@@ -126,6 +129,12 @@ packages:
 
   '@mercuryworkshop/bare-mux@2.1.7':
     resolution: {integrity: sha512-BUamyc7jsIFbWQVVWjVjaD+Wot77EPwolkrbP3UuIs6QeHR1RY52+IR2fq3GkRAbOOrAZNT7EgZSsupkh1NowQ==}
+
+  '@mercuryworkshop/epoxy-tls@2.1.19-1':
+    resolution: {integrity: sha512-lF3WVDmKDWfClgFaDm1OAGI6PStcUUKUjNh2AJbfmLXEGh+dT4nvsuTY2QGRImnajCboIRyrpx9eGNY0egZSVg==}
+
+  '@mercuryworkshop/epoxy-transport@3.0.1':
+    resolution: {integrity: sha512-8YzL73WaXZJLBRydmmY6NNPt5leB8ygBYuqgLn4+pGQ+wgi+JUC7ZdBQrA86TR6Oue3twbdfDvLRp48bzZ7DSw==}
 
   '@mercuryworkshop/libcurl-transport@1.5.2':
     resolution: {integrity: sha512-E0tD/3W6HE99ypc7CStpchU6xs+TP5u2vms/9q/46BShblB2pbRCNeXHBlvXqdz97nh2Xh4A68DryDt5CM29Dg==}
@@ -898,6 +907,12 @@ snapshots:
   '@lukeed/ms@2.0.2': {}
 
   '@mercuryworkshop/bare-mux@2.1.7': {}
+
+  '@mercuryworkshop/epoxy-tls@2.1.19-1': {}
+
+  '@mercuryworkshop/epoxy-transport@3.0.1':
+    dependencies:
+      '@mercuryworkshop/epoxy-tls': 2.1.19-1
 
   '@mercuryworkshop/libcurl-transport@1.5.2':
     dependencies:

--- a/public/index.js
+++ b/public/index.js
@@ -34,6 +34,14 @@ scramjet.init();
 
 const connection = new BareMux.BareMuxConnection("/baremux/worker.js");
 
+const wispUrl =
+	(location.protocol === "https:" ? "wss" : "ws") +
+	"://" +
+	location.host +
+	"/wisp/";
+
+connection.setTransport("/epoxy/index.mjs", [{ wisp: wispUrl }]);
+
 form.addEventListener("submit", async (event) => {
 	event.preventDefault();
 
@@ -47,16 +55,6 @@ form.addEventListener("submit", async (event) => {
 
 	const url = search(address.value, searchEngine.value);
 
-	let wispUrl =
-		(location.protocol === "https:" ? "wss" : "ws") +
-		"://" +
-		location.host +
-		"/wisp/";
-	if ((await connection.getTransport()) !== "/libcurl/index.mjs") {
-		await connection.setTransport("/libcurl/index.mjs", [
-			{ websocket: wispUrl },
-		]);
-	}
 	const frame = scramjet.createFrame();
 	frame.frame.id = "sj-frame";
 	document.body.appendChild(frame.frame);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import { createServer } from "node:http";
 import { fileURLToPath } from "url";
 import { hostname } from "node:os";
+import { realpathSync } from "node:fs";
+import { join } from "node:path";
 import { server as wisp, logging } from "@mercuryworkshop/wisp-js/server";
 import Fastify from "fastify";
 import fastifyStatic from "@fastify/static";
@@ -10,6 +12,8 @@ import { libcurlPath } from "@mercuryworkshop/libcurl-transport";
 import { baremuxPath } from "@mercuryworkshop/bare-mux/node";
 
 const publicPath = fileURLToPath(new URL("../public/", import.meta.url));
+const rootPath = fileURLToPath(new URL("../", import.meta.url));
+const epoxyPath = realpathSync(join(rootPath, "node_modules", "@mercuryworkshop", "epoxy-transport", "dist"));
 
 // Wisp Configuration: Refer to the documentation at https://www.npmjs.com/package/@mercuryworkshop/wisp-js
 
@@ -49,6 +53,12 @@ fastify.register(fastifyStatic, {
 fastify.register(fastifyStatic, {
 	root: libcurlPath,
 	prefix: "/libcurl/",
+	decorateReply: false,
+});
+
+fastify.register(fastifyStatic, {
+	root: epoxyPath,
+	prefix: "/epoxy/",
 	decorateReply: false,
 });
 


### PR DESCRIPTION
libcurl transport fails on iPad Safari and some desktop WebKit browsers, breaking sites like Facebook. Epoxy transport handles these correctly.